### PR TITLE
Build tools in Elm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ instance/**/*.js
 run_with_credentials.sh
 file
 users.db
+bootstrap.js

--- a/bootstrapper/Bootstrapper.elm
+++ b/bootstrapper/Bootstrapper.elm
@@ -1,0 +1,22 @@
+module Bootstrapper where
+{-|
+This is a very naughty module indeed.
+
+Swap out the two arguments to bootstrap with the name of your module
+and the name of the output file.
+
+That output file will then be ran whenever you call this script.
+
+This script is also self-bootstrapping, simply run node on it and it will
+handle the rest.
+
+-}
+import Native.Bootstrapper
+
+bootstrap : String -> String -> ()
+bootstrap =
+    Native.Bootstrapper.bootstrap
+
+port run : ()
+port run =
+    bootstrap "instance/server/Main" "instance/server/main.js"

--- a/bootstrapper/Native/Bootstrapper.js
+++ b/bootstrapper/Native/Bootstrapper.js
@@ -1,0 +1,55 @@
+
+var bootstrap = function(fs, exec, compiler){
+    var compile = function(file, outFile, onClose){
+        compiler.compile([file + '.elm'], {
+            output: outFile,
+            yes: true
+        }).on('close', onClose);
+    };
+
+    return function(filename, output){
+        console.log("here");
+        compile(filename, output, function(){
+            var dirIndex = filename.lastIndexOf('/');
+            var lastFileName = filename.substr(dirIndex + 1);
+
+            fs.appendFileSync(output, "\nElm.worker(Elm." + lastFileName + ");")
+            var child = exec('node ' + output);
+
+            child.stdout.on('data', console.log);
+            child.stderr.on('data', console.error);
+            child.on('close', function(code) {
+                console.log('closing code: ' + code);
+            });
+        });
+    };
+};
+
+var make = function make(localRuntime) {
+    localRuntime.Native = localRuntime.Native || {};
+    localRuntime.Native.Bootstrapper = localRuntime.Native.Bootstrapper || {};
+
+    if (localRuntime.Native.Bootstrapper.values) {
+        return localRuntime.Native.Bootstrapper.values;
+    }
+    var fs = require('fs');
+    var exec = require('child_process').exec;
+    var compiler = require('node-elm-compiler');
+
+
+    return {
+        bootstrap: F2(bootstrap(fs, exec, compiler))
+    };
+};
+
+Elm.Native.Bootstrapper = {};
+Elm.Native.Bootstrapper.make = make;
+
+if (typeof window === "undefined") {
+    window = global;
+}
+
+setTimeout(function() {
+    console.log("starting elm..");
+    Elm.worker(Elm.Bootstrapper);
+}, 1000);

--- a/bootstrapper/elm-package.json
+++ b/bootstrapper/elm-package.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        "."
+    ],
+    "exposed-modules": [],
+    "native-modules": true,
+    "dependencies": {
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+    },
+    "elm-version": "0.16.0 <= v < 0.17.0"
+}

--- a/instance/server/run.sh
+++ b/instance/server/run.sh
@@ -1,4 +1,0 @@
-# TODO: move over to using a build folder
-elm make instance/server/Main.elm --output=instance/server/main.js
-echo "Elm.worker(Elm.Main);" >> instance/server/main.js
-node instance/server/main.js


### PR DESCRIPTION
Here's a crazy idea:

What if everything was written in Elm?

I mean, we already have
- [x] Full client side support (JS, html, stylesheets)
- [x] Server support (with node!)
- [x] Database support (with node bindings!)

Why not go one more, and add build tools for Elm, in Elm too?

How do we do that? By abusing Elm, of course!

Firstly, there are some rules to make this work:
- Any Native code will be injected into the output file if the Native module is imported anywhere
- The Native code will be injected as found in the file
- Native code is bound before compiled Elm code
- timeouts make thing run later.
- ports get run by default if you include the file as `Elm.worker(Elm.module)`

With this in mind, it's pretty easy to make Elm output a file that can run itself. Or one that can run another file!

Add this little guy to the end of the Native module and watch what happens

``` javascript
setTimeout(function() {
    console.log("starting elm..");
    Elm.worker(Elm.Bootstrapper);
, 1000);
```

At the moment, this file will -
- [x] Run itself
- [x] Compile other modules
- [x] Run the module it just compiled

In the real world, there's not really a case for this to be used. This is just here as an example - if you want an Elm project that can replace any other tool you have except for `node`, here's the guy to gun for.
