### PR TITLE
Adds buffertools to simply read indexOf buffer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/NoRedInk/take-home#readme",
   "dependencies": {
+    "buffertools": "^2.1.3",
     "knox": "0.9.2",
     "mime": "1.3.4",
     "moment": "^2.10.6",

--- a/src/Native/Http/Response/Write.js
+++ b/src/Native/Http/Response/Write.js
@@ -1,3 +1,5 @@
+var buffertools = require('buffertools');
+
 var COMPILED_DIR = '.comp';
 
 var writeHead = function writeHead(Task) {
@@ -86,7 +88,7 @@ var writeElm = function writeElm(fs, mime, crypto, compiler, Task){
                 res.writeHead('Content-Type', type);
 
                 fs.readFile(outFile, function (e, data) {
-                    var headClose = data.indexOf("</head>");
+                    var headClose = buffertools.indexOf(data, "</head>");
                     var outData = data;
                     if (!(typeof appendable === "undefined" || appendable === null)){
                         var extra = new Buffer("<script>" + appendable + "</script>");


### PR DESCRIPTION
This PR adds [node-buffertools](https://github.com/bnoordhuis/node-buffertools) to `main.js` so we can use `indexOf` on a buffer.

Solves this error:

```
/Users/name/Web/take-home/instance/server/main.js:16006
var headClose = data.indexOf("</head>");
                     ^
TypeError: undefined is not a function
   at /Users/chrisbuttery/Web/take-home/instance/server/main.js:16006:42
   at fs.js:334:14
   at FSReqWrap.oncomplete (fs.js:95:15)
```