### PR TITLE
Add parse-link-header to npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "multiparty": "4.1.2",
     "node-elm-compiler": "2.3.1",
     "node-uuid": "1.4.7",
+    "parse-link-header": "^0.4.1",
     "vdom-to-html": "2.2.0",
     "virtual-dom": "2.1.1"
   },


### PR DESCRIPTION
I got an error when initially starting the server:
```
...
Success! Compiled 85 modules.
Successfully generated instance/server/main.js
Cannot find module 'parse-link-header'
./take-home/instance/server/main.js:415
				throw error;
				^

Error: Cannot find module 'parse-link-header'
...
```

Adding as a dependency resolved this.